### PR TITLE
refactor(Scripts/Ulduar): leverage DoorData and persistent data systems

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -326,13 +326,6 @@ struct boss_vezax : public BossAI
     {
         _JustDied();
         Talk(SAY_DEATH);
-
-        if (GameObject* door = me->FindNearestGameObject(GO_VEZAX_DOOR, 500.0f))
-            if (door->GetGoState() != GO_STATE_ACTIVE)
-            {
-                door->SetLootState(GO_READY);
-                door->UseDoorOrButton(0, false);
-            }
     }
 
     void KilledUnit(Unit* who) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -231,11 +231,6 @@ struct boss_hodir : public BossAI
         me->RemoveAllAuras();
         instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_BITING_COLD_PLAYER_AURA);
 
-        if (GameObject* go = me->FindNearestGameObject(GO_HODIR_FRONTDOOR, 900.0f))
-        {
-            go->SetGoState(GO_STATE_ACTIVE);
-        }
-
         // Reset helpers
         if (!summons.size())
             SpawnHelpers();
@@ -253,14 +248,7 @@ struct boss_hodir : public BossAI
         Talk(TEXT_AGGRO);
 
         if (instance->GetBossState(BOSS_HODIR) != DONE)
-        {
             instance->SetBossState(BOSS_HODIR, IN_PROGRESS);
-        }
-
-        if (GameObject* go = me->FindNearestGameObject(GO_HODIR_FRONTDOOR, 300.0f))
-        {
-            go->SetGoState(GO_STATE_READY);
-        }
     }
 
     GameObject* GetHardmodeChest()
@@ -341,28 +329,6 @@ struct boss_hodir : public BossAI
 
                 events.Reset();
                 summons.DespawnAll();
-
-                if (GameObject* d = me->FindNearestGameObject(GO_HODIR_FROZEN_DOOR, 250.0f))
-                {
-                    if (d->GetGoState() != GO_STATE_ACTIVE )
-                    {
-                        d->SetLootState(GO_READY);
-                        d->UseDoorOrButton(0, false);
-                    }
-                }
-                if (GameObject* d = me->FindNearestGameObject(GO_HODIR_DOOR, 250.0f))
-                {
-                    if (d->GetGoState() != GO_STATE_ACTIVE )
-                    {
-                        d->SetLootState(GO_READY);
-                        d->UseDoorOrButton(0, false);
-                    }
-                }
-
-                if (GameObject* go = me->FindNearestGameObject(GO_HODIR_FRONTDOOR, 300.0f))
-                {
-                    go->SetGoState(GO_STATE_ACTIVE);
-                }
 
                 Talk(TEXT_DEATH);
                 scheduler.Schedule(14s, [this](TaskContext /*context*/)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -740,15 +740,6 @@ struct boss_mimiron : public BossAI
 
                     DoCastSelf(SPELL_SLEEP_VISUAL_1);
 
-                    if (instance)
-                        for( uint16 i = 0; i < 3; ++i )
-                            if (GameObject* door = instance->GetGameObject(DATA_GO_MIMIRON_DOOR_1 + i))
-                                    if (door->GetGoState() != GO_STATE_ACTIVE )
-                                    {
-                                        door->SetLootState(GO_READY);
-                                        door->UseDoorOrButton(0, false);
-                                    }
-
                     instance->DoUpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE, NPC_LEVIATHAN_MKII, 1, me);
 
                     if (hardmode)
@@ -828,14 +819,6 @@ struct boss_mimiron : public BossAI
 
     void ResetGameObjects()
     {
-        for (uint16 i = 0; i < 3; ++i)
-            if (GameObject* door = instance->GetGameObject(DATA_GO_MIMIRON_DOOR_1 + i))
-                if (door->GetGoState() != GO_STATE_ACTIVE)
-                    {
-                        door->SetLootState(GO_READY);
-                        door->UseDoorOrButton(0, false);
-                    }
-
         if (GameObject* elevator = me->FindNearestGameObject(GO_MIMIRON_ELEVATOR, 200.0f))
         {
             if (elevator->GetGoState() != GO_STATE_ACTIVE )
@@ -857,14 +840,6 @@ struct boss_mimiron : public BossAI
 
     void CloseDoorAndButton()
     {
-        for (uint16 i = 0; i < 3; ++i)
-            if (GameObject* door = instance->GetGameObject(DATA_GO_MIMIRON_DOOR_1 + i))
-                if (door->GetGoState() != GO_STATE_READY)
-                    {
-                        door->SetLootState(GO_READY);
-                        door->UseDoorOrButton(0, false);
-                    }
-
         if (GameObject* button = me->FindNearestGameObject(GO_BUTTON, 200.0f))
             if (button->GetGoState() != GO_STATE_ACTIVE)
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -31,12 +31,29 @@
 DoorData const doorData[] =
 {
     { GO_LEVIATHAN_DOORS,   BOSS_LEVIATHAN, DOOR_TYPE_ROOM    },
+    { GO_LIGHTNING_WALL1,   BOSS_LEVIATHAN, DOOR_TYPE_PASSAGE },
     { GO_XT002_DOORS,       BOSS_XT002,     DOOR_TYPE_ROOM    },
     { GO_KOLOGARN_DOORS,    BOSS_KOLOGARN,  DOOR_TYPE_ROOM    },
     { GO_ASSEMBLY_DOORS,    BOSS_ASSEMBLY,  DOOR_TYPE_ROOM    },
     { GO_ARCHIVUM_DOORS,    BOSS_ASSEMBLY,  DOOR_TYPE_PASSAGE },
-    { GO_YOGG_SARON_DOORS,  BOSS_YOGGSARON, DOOR_TYPE_ROOM    },
-    { 0,                    0,              DOOR_TYPE_ROOM    }
+    { GO_MIMIRON_DOOR_1,    BOSS_MIMIRON,   DOOR_TYPE_ROOM    },
+    { GO_MIMIRON_DOOR_2,    BOSS_MIMIRON,   DOOR_TYPE_ROOM    },
+    { GO_MIMIRON_DOOR_3,    BOSS_MIMIRON,   DOOR_TYPE_ROOM    },
+    { GO_HODIR_FRONTDOOR,   BOSS_HODIR,     DOOR_TYPE_ROOM    },
+    { GO_HODIR_FROZEN_DOOR, BOSS_HODIR,     DOOR_TYPE_PASSAGE },
+    { GO_HODIR_DOOR,        BOSS_HODIR,     DOOR_TYPE_PASSAGE },
+    { GO_KEEPERS_GATE,                  BOSS_HODIR,     DOOR_TYPE_PASSAGE },
+    { GO_KEEPERS_GATE,                  BOSS_MIMIRON,   DOOR_TYPE_PASSAGE },
+    { GO_KEEPERS_GATE,                  BOSS_THORIM,    DOOR_TYPE_PASSAGE },
+    { GO_KEEPERS_GATE,                  BOSS_FREYA,     DOOR_TYPE_PASSAGE },
+    { GO_VEZAX_DOOR,                    BOSS_VEZAX,     DOOR_TYPE_PASSAGE },
+    { GO_YOGG_SARON_DOORS,              BOSS_YOGGSARON, DOOR_TYPE_ROOM    },
+    { GO_DOODAD_UL_SIGILDOOR_03,        BOSS_ALGALON,   DOOR_TYPE_ROOM    },
+    { GO_DOODAD_UL_UNIVERSEFLOOR_01,    BOSS_ALGALON,   DOOR_TYPE_ROOM    },
+    { GO_DOODAD_UL_UNIVERSEFLOOR_02,    BOSS_ALGALON,   DOOR_TYPE_SPAWN_HOLE },
+    { GO_DOODAD_UL_UNIVERSEGLOBE01,     BOSS_ALGALON,   DOOR_TYPE_SPAWN_HOLE },
+    { GO_DOODAD_UL_ULDUAR_TRAPDOOR_03,  BOSS_ALGALON,   DOOR_TYPE_SPAWN_HOLE },
+    { 0,                                0,              DOOR_TYPE_ROOM    }
 };
 
 ObjectData const creatureData[] =
@@ -132,6 +149,7 @@ public:
         {
             SetHeaders(DataHeader);
             SetBossNumber(MAX_ENCOUNTER);
+            SetPersistentDataCount(MAX_PERSISTENT_DATA);
             LoadDoorData(doorData);
             LoadObjectData(creatureData, gameobjectData);
             Initialize();
@@ -140,10 +158,6 @@ public:
             m_difficulty = (pMap->Is25ManRaid() ? 0 : 1);
         };
 
-        // Only used for TYPE_WATCHERS bitmask
-        uint32 m_watchersMask;
-        uint32 C_of_Ulduar_MASK;
-
         int m_difficulty;
 
         // Flame Leviathan
@@ -151,21 +165,11 @@ public:
         ObjectGuid m_RepairSGUID[2];
         bool m_leviathanTowers[4];
         GuidList _leviathanVehicles;
-        uint32 m_unbrokenAchievement;
-        uint32 m_mageBarrier;
 
         // Hodir
         bool hmHodir;
         Position normalChestPosition = { 1967.152588f, -204.188461f, 432.686951f, 5.50957f };
         Position hardChestPosition = { 2035.94600f, -202.084885f, 432.686859f, 3.164077f };
-
-        // Freya
-        uint32 m_conspeedatoryAttempt;
-
-        // Yogg-Saron
-
-        // Algalon
-        uint32 m_algalonTimer;
 
         // Ancient Gate
         const Position triggerAncientGatePosition = { 1883.65f, 269.272f, 418.406f };
@@ -177,26 +181,15 @@ public:
 
         void Initialize() override
         {
-            // Bosses
-            m_watchersMask = 0;
-            C_of_Ulduar_MASK = 0;
-
             // Flame Leviathan
             for (uint8 i = 0; i < 4; ++i)
                 m_leviathanTowers[i] = true;
 
             _leviathanVehicles.clear();
-            m_unbrokenAchievement   = 1;
-            m_mageBarrier           = 0;
+            StorePersistentData(PERSISTENT_DATA_UNBROKEN, 1);
 
             // Hodir
             hmHodir = true; // If players fail the Hardmode then becomes false
-
-            // Freya
-            m_conspeedatoryAttempt  = 0;
-
-            // Algalon
-            m_algalonTimer          = 0;
 
             // Shared
             _events.Reset();
@@ -205,9 +198,10 @@ public:
 
         void FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet) override
         {
+            uint32 algalonTimer = GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER);
             packet.Worldstates.reserve(2);
-            packet.Worldstates.emplace_back(WORLD_STATE_ULDUAR_ALGALON_TIMER_ENABLED, (m_algalonTimer && m_algalonTimer <= 60) ? 1 : 0);
-            packet.Worldstates.emplace_back(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, std::min<int32>(m_algalonTimer, 60));
+            packet.Worldstates.emplace_back(WORLD_STATE_ULDUAR_ALGALON_TIMER_ENABLED, (algalonTimer && algalonTimer <= 60) ? 1 : 0);
+            packet.Worldstates.emplace_back(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, std::min<uint32>(algalonTimer, 60));
         }
 
         void OnPlayerEnter(Player* player) override
@@ -227,20 +221,21 @@ public:
                 }
             }
 
-            if (!GetObjectGuid(BOSS_ALGALON) && m_algalonTimer && (m_algalonTimer <= 60 || m_algalonTimer == TIMER_ALGALON_TO_SUMMON))
+            uint32 algalonTimer = GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER);
+            if (!GetObjectGuid(BOSS_ALGALON) && algalonTimer && (algalonTimer <= 60 || algalonTimer == TIMER_ALGALON_TO_SUMMON))
             {
                 TempSummon* algalon = instance->SummonCreature(NPC_ALGALON, AlgalonLandPos);
                 if (!algalon)
                     return;
 
-                if (m_algalonTimer <= 60)
+                if (algalonTimer <= 60)
                 {
                     _events.RescheduleEvent(EVENT_UPDATE_ALGALON_TIMER, 1min);
                     algalon->AI()->DoAction(ACTION_INIT_ALGALON);
                 }
-                else // if (m_algalonTimer = TIMER_ALGALON_TO_SUMMON)
+                else // if (algalonTimer == TIMER_ALGALON_TO_SUMMON)
                 {
-                    m_algalonTimer = TIMER_ALGALON_SUMMONED;
+                    StorePersistentData(PERSISTENT_DATA_ALGALON_TIMER, TIMER_ALGALON_SUMMONED);
                     algalon->SetImmuneToPC(false);
                 }
             }
@@ -290,12 +285,6 @@ public:
                             go->SetGoState(GO_STATE_ACTIVE_ALTERNATIVE);
                     }
                     break;
-                case BOSS_ASSEMBLY:
-                    // Assembly doors handled by DoorData, archivum
-                    // doors stay open only after DONE
-                    if (GameObject* go = GetGameObject(DATA_ARCHIVUM_DOORS))
-                        go->SetGoState(state == DONE ? GO_STATE_ACTIVE : GO_STATE_READY);
-                    break;
                 case BOSS_MIMIRON:
                     if (state == IN_PROGRESS)
                         m_mimironTramUsed = true;
@@ -307,43 +296,12 @@ public:
                     {
                         scheduler.Schedule(45s, [this](TaskContext /*context*/)
                         {
-                            if (GameObject* go = GetGameObject(DATA_KEEPERS_GATE))
-                            {
-                                go->RemoveGameObjectFlag(GO_FLAG_LOCKED);
-                                if (Creature* trigger = instance->SummonCreature(NPC_ANCIENT_GATE_WORLD_TRIGGER, triggerAncientGatePosition, nullptr, 10 * IN_MILLISECONDS))
-                                    trigger->AI()->Talk(EMOTE_ANCIENT_GATE_UNLOCKED);
-                            }
+                            if (Creature* trigger = instance->SummonCreature(NPC_ANCIENT_GATE_WORLD_TRIGGER, triggerAncientGatePosition, nullptr, 10 * IN_MILLISECONDS))
+                                trigger->AI()->Talk(EMOTE_ANCIENT_GATE_UNLOCKED);
                         });
                     }
                     if (type == BOSS_HODIR && state == DONE)
                         setChestsLootable(BOSS_HODIR);
-                    break;
-                case BOSS_ALGALON:
-                    if (GameObject* go = GetGameObject(DATA_SIGILDOOR_03))
-                    {
-                        go->SetGoState(state != IN_PROGRESS ? GO_STATE_ACTIVE : GO_STATE_READY);
-                        go->EnableCollision(false);
-                    }
-                    if (GameObject* go = GetGameObject(DATA_UNIVERSE_FLOOR_01))
-                    {
-                        go->SetGoState(state != IN_PROGRESS ? GO_STATE_ACTIVE : GO_STATE_READY);
-                        go->EnableCollision(false);
-                    }
-                    if (GameObject* go = GetGameObject(DATA_UNIVERSE_FLOOR_02))
-                    {
-                        go->SetGoState(state == IN_PROGRESS ? GO_STATE_ACTIVE : GO_STATE_READY);
-                        go->EnableCollision(false);
-                    }
-                    if (GameObject* go = GetGameObject(DATA_UNIVERSE_GLOBE))
-                    {
-                        go->SetGoState(state == IN_PROGRESS ? GO_STATE_ACTIVE : GO_STATE_READY);
-                        go->EnableCollision(false);
-                    }
-                    if (GameObject* go = GetGameObject(DATA_ALGALON_TRAPDOOR))
-                    {
-                        go->SetGoState(state == IN_PROGRESS ? GO_STATE_ACTIVE : GO_STATE_READY);
-                        go->EnableCollision(false);
-                    }
                     break;
                 default:
                     break;
@@ -466,7 +424,7 @@ public:
                     }
                     break;
                 case NPC_ALGALON:
-                    if (!m_algalonTimer)
+                    if (!GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER))
                         creature->DespawnOrUnsummon();
                     break;
                 //! These creatures are summoned by something else than Algalon
@@ -517,9 +475,6 @@ public:
                             m_RepairSGUID[0] = gameObject->GetGUID();
                         break;
                     }
-                case GO_LIGHTNING_WALL1:
-                    OpenIfDone(BOSS_LEVIATHAN, gameObject, GO_STATE_ACTIVE);
-                    break;
                 case GO_MIMIRONS_TARGETTING_CRYSTAL:
                     OpenIfDone(BOSS_LEVIATHAN, gameObject, GO_STATE_ACTIVE);
                     m_leviathanVisualTowers[3][0] = gameObject->GetGUID();
@@ -559,9 +514,6 @@ public:
                 case GO_KOLOGARN_BRIDGE:
                     OpenIfDone(BOSS_KOLOGARN, gameObject, GO_STATE_READY);
                     break;
-                case GO_ARCHIVUM_DOORS:
-                    OpenIfDone(BOSS_ASSEMBLY, gameObject, GO_STATE_ACTIVE);
-                    break;
                 case GO_KEEPERS_GATE:
                     if (GetBossState(BOSS_MIMIRON) == DONE && GetBossState(BOSS_FREYA) == DONE && GetBossState(BOSS_HODIR) == DONE && GetBossState(BOSS_THORIM) == DONE)
                         gameObject->RemoveGameObjectFlag(GO_FLAG_LOCKED);
@@ -569,23 +521,6 @@ public:
                 // Mimiron, Hodir, Vezax
                 case GO_MIMIRON_ELEVATOR:
                     gameObject->EnableCollision(false);
-                    break;
-                case GO_HODIR_FROZEN_DOOR:
-                case GO_HODIR_DOOR:
-                    if (GetBossState(BOSS_HODIR) == DONE)
-                        if (gameObject->GetGoState() != GO_STATE_ACTIVE )
-                        {
-                            gameObject->SetLootState(GO_READY);
-                            gameObject->UseDoorOrButton(0, false);
-                        }
-                    break;
-                case GO_VEZAX_DOOR:
-                    if (GetBossState(BOSS_VEZAX) == DONE )
-                        if (gameObject->GetGoState() != GO_STATE_ACTIVE )
-                        {
-                            gameObject->SetLootState(GO_READY);
-                            gameObject->UseDoorOrButton(0, false);
-                        }
                     break;
                 case GO_SNOW_MOUND:
                     gameObject->EnableCollision(false);
@@ -598,15 +533,15 @@ public:
                 // Algalon the Observer
                 case GO_CELESTIAL_PLANETARIUM_ACCESS_10:
                 case GO_CELESTIAL_PLANETARIUM_ACCESS_25:
-                    if (m_algalonTimer)
+                    if (GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER))
                         gameObject->SetGameObjectFlag(GO_FLAG_IN_USE);
                     break;
                 case GO_DOODAD_UL_SIGILDOOR_01:
-                    if (m_algalonTimer)
+                    if (GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER))
                         gameObject->SetGoState(GO_STATE_ACTIVE);
                     break;
                 case GO_DOODAD_UL_SIGILDOOR_02:
-                    if (m_algalonTimer)
+                    if (GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER))
                         gameObject->SetGoState(GO_STATE_ACTIVE);
                     break;
                 // Herbs
@@ -658,14 +593,14 @@ public:
                     }
                     break;
                 case TYPE_WATCHERS:
-                    m_watchersMask |= 1 << data;
+                    StorePersistentData(PERSISTENT_DATA_WATCHERS_MASK, GetPersistentData(PERSISTENT_DATA_WATCHERS_MASK) | (1 << data));
                     [[fallthrough]];
                 case EVENT_KEEPER_TELEPORTED:
                     if (Creature* sara = GetCreature(DATA_SARA))
                         sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     break;
                 case DATA_MAGE_BARRIER:
-                    m_mageBarrier = data;
+                    StorePersistentData(PERSISTENT_DATA_MAGE_BARRIER, data);
                     break;
 
                 case EVENT_TOWER_OF_LIFE_DESTROYED:
@@ -688,22 +623,19 @@ public:
                     SpawnLeviathanEncounterVehicles(data);
                     return;
                 case DATA_UNBROKEN_ACHIEVEMENT:
-                    m_unbrokenAchievement = data;
-                    SaveToDB();
+                    StorePersistentData(PERSISTENT_DATA_UNBROKEN, data);
                     return;
                 case DATA_DESPAWN_ALGALON:
                     DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_TIMER_ENABLED, 1);
                     DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, 60);
-                    m_algalonTimer = 60;
+                    StorePersistentData(PERSISTENT_DATA_ALGALON_TIMER, 60);
                     _events.RescheduleEvent(EVENT_UPDATE_ALGALON_TIMER, 1min);
-                    SaveToDB();
                     return;
                 case DATA_ALGALON_SUMMON_STATE:
                 case DATA_ALGALON_DEFEATED:
                     DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_TIMER_ENABLED, 0);
-                    m_algalonTimer = (type == DATA_ALGALON_DEFEATED ? TIMER_ALGALON_DEFEATED : TIMER_ALGALON_SUMMONED);
+                    StorePersistentData(PERSISTENT_DATA_ALGALON_TIMER, type == DATA_ALGALON_DEFEATED ? TIMER_ALGALON_DEFEATED : TIMER_ALGALON_SUMMONED);
                     _events.CancelEvent(EVENT_UPDATE_ALGALON_TIMER);
-                    SaveToDB();
                     return;
                 // Achievement
                 case DATA_DWARFAGEDDON:
@@ -774,8 +706,6 @@ public:
                     break;
             }
 
-            if (type == TYPE_WATCHERS)
-                SaveToDB();
         }
 
         ObjectGuid GetGuidData(uint32 data) const override
@@ -798,7 +728,7 @@ public:
             switch (type)
             {
                 case TYPE_WATCHERS:
-                    return m_watchersMask;
+                    return GetPersistentData(PERSISTENT_DATA_WATCHERS_MASK);
 
                 case EVENT_TOWER_OF_LIFE_DESTROYED:
                 case EVENT_TOWER_OF_STORM_DESTROYED:
@@ -807,10 +737,10 @@ public:
                     return m_leviathanTowers[type - EVENT_TOWER_OF_LIFE_DESTROYED];
 
                 case DATA_MAGE_BARRIER:
-                    return m_mageBarrier;
+                    return GetPersistentData(PERSISTENT_DATA_MAGE_BARRIER);
 
                 case DATA_UNBROKEN_ACHIEVEMENT:
-                    return m_unbrokenAchievement;
+                    return GetPersistentData(PERSISTENT_DATA_UNBROKEN);
 
                 case DATA_CALL_TRAM:
                     return m_mimironTramUsed;
@@ -830,11 +760,11 @@ public:
             }
             else if (unit->IsCreature() && unit->GetAreaId() == AREA_THE_CONSERVATORY_OF_LIFE)
             {
-                if (GameTime::GetGameTime().count() > (m_conspeedatoryAttempt + DAY))
+                uint32 conspeedatory = GetPersistentData(PERSISTENT_DATA_CONSPEEDATORY);
+                if (GameTime::GetGameTime().count() > (conspeedatory + DAY))
                 {
                     DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, 21597 /*CON-SPEED-ATORY_TIMED_CRITERIA*/);
-                    m_conspeedatoryAttempt = GameTime::GetGameTime().count();
-                    SaveToDB();
+                    StorePersistentData(PERSISTENT_DATA_CONSPEEDATORY, GameTime::GetGameTime().count());
                 }
             }
 
@@ -842,55 +772,36 @@ public:
             if (unit->IsPlayer())
                 for (uint8 i = 0; i <= 12; ++i)
                 {
-                    bool go = false;
+                    bool inCombat = false;
                     if (i == BOSS_LEVIATHAN)
                     {
                         if (Creature* c = GetCreature(BOSS_LEVIATHAN))
                             if (c->IsInCombat())
-                                go = true;
+                                inCombat = true;
                     }
                     else
-                        go = (GetBossState(i) == IN_PROGRESS);
+                        inCombat = (GetBossState(i) == IN_PROGRESS);
 
-                    if (go && (C_of_Ulduar_MASK & (1 << i)) == 0)
-                    {
-                        C_of_Ulduar_MASK |= (1 << i);
-                        SaveToDB();
-                    }
+                    uint32 mask = GetPersistentData(PERSISTENT_DATA_C_OF_ULDUAR_MASK);
+                    if (inCombat && (mask & (1 << i)) == 0)
+                        StorePersistentData(PERSISTENT_DATA_C_OF_ULDUAR_MASK, mask | (1 << i));
                 }
         }
 
-        void ReadSaveDataMore(std::istringstream& data) override
+        void Load(char const* data) override
         {
-            // Boss states 0-13 are read by base InstanceScript.
-            data >> m_watchersMask;
-            data >> m_conspeedatoryAttempt;
-            data >> m_unbrokenAchievement;
-            data >> m_algalonTimer;
+            InstanceScript::Load(data);
 
-            if (m_algalonTimer == TIMER_ALGALON_SUMMONED)
-                m_algalonTimer = TIMER_ALGALON_TO_SUMMON;
+            uint32 algalonTimer = GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER);
+            if (algalonTimer == TIMER_ALGALON_SUMMONED)
+                StorePersistentData(PERSISTENT_DATA_ALGALON_TIMER, TIMER_ALGALON_TO_SUMMON);
 
-            if (m_algalonTimer && m_algalonTimer <= 60 && GetBossState(BOSS_ALGALON) != DONE)
+            algalonTimer = GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER);
+            if (algalonTimer && algalonTimer <= 60 && GetBossState(BOSS_ALGALON) != DONE)
             {
                 DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_TIMER_ENABLED, 1);
-                DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, m_algalonTimer);
+                DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, algalonTimer);
             }
-
-            data >> C_of_Ulduar_MASK;
-            data >> m_mageBarrier;
-        }
-
-        void WriteSaveDataMore(std::ostringstream& data) override
-        {
-            // Boss states 0-13 are written by base InstanceScript.
-            // Only write extra non-boss data here.
-            data << m_watchersMask << ' '
-                << m_conspeedatoryAttempt << ' '
-                << m_unbrokenAchievement << ' '
-                << m_algalonTimer << ' '
-                << C_of_Ulduar_MASK << ' '
-                << m_mageBarrier;
         }
 
         void Update(uint32 diff) override
@@ -904,12 +815,14 @@ public:
             switch (_events.ExecuteEvent())
             {
                 case EVENT_UPDATE_ALGALON_TIMER:
-                    if (m_algalonTimer == TIMER_ALGALON_DEFEATED)
+                {
+                    uint32 algalonTimer = GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER);
+                    if (algalonTimer == TIMER_ALGALON_DEFEATED)
                         return;
 
-                    SaveToDB();
-                    DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, --m_algalonTimer);
-                    if (m_algalonTimer)
+                    StorePersistentData(PERSISTENT_DATA_ALGALON_TIMER, --algalonTimer);
+                    DoUpdateWorldState(WORLD_STATE_ULDUAR_ALGALON_DESPAWN_TIMER, algalonTimer);
+                    if (algalonTimer)
                     {
                         _events.Repeat(1min);
                         return;
@@ -918,6 +831,7 @@ public:
                     SetData(DATA_ALGALON_DEFEATED, 1);
                     if (Creature* algalon = GetCreature(BOSS_ALGALON))
                         algalon->AI()->DoAction(ACTION_DESPAWN_ALGALON);
+                }
             }
         }
 
@@ -925,47 +839,48 @@ public:
 
         bool CheckAchievementCriteriaMeet(uint32 criteria_id, Player const*  /*source*/, Unit const*  /*target*/, uint32  /*miscvalue1*/) override
         {
+            uint32 mask = GetPersistentData(PERSISTENT_DATA_C_OF_ULDUAR_MASK);
             switch (criteria_id)
             {
                 case 10042:
                 case 10352:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_LEVIATHAN)) == 0;
+                    return (mask & (1 << BOSS_LEVIATHAN)) == 0;
                 case 10342:
                 case 10355:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_IGNIS)) == 0;
+                    return (mask & (1 << BOSS_IGNIS)) == 0;
                 case 10340:
                 case 10353:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_RAZORSCALE)) == 0;
+                    return (mask & (1 << BOSS_RAZORSCALE)) == 0;
                 case 10341:
                 case 10354:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_XT002)) == 0;
+                    return (mask & (1 << BOSS_XT002)) == 0;
                 case 10598:
                 case 10599:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_ASSEMBLY)) == 0;
+                    return (mask & (1 << BOSS_ASSEMBLY)) == 0;
                 case 10348:
                 case 10357:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_KOLOGARN)) == 0;
+                    return (mask & (1 << BOSS_KOLOGARN)) == 0;
                 case 10351:
                 case 10363:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_AURIAYA)) == 0;
+                    return (mask & (1 << BOSS_AURIAYA)) == 0;
                 case 10439:
                 case 10719:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_HODIR)) == 0;
+                    return (mask & (1 << BOSS_HODIR)) == 0;
                 case 10403:
                 case 10404:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_THORIM)) == 0;
+                    return (mask & (1 << BOSS_THORIM)) == 0;
                 case 10582:
                 case 10583:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_FREYA)) == 0;
+                    return (mask & (1 << BOSS_FREYA)) == 0;
                 case 10347:
                 case 10361:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_MIMIRON)) == 0;
+                    return (mask & (1 << BOSS_MIMIRON)) == 0;
                 case 10349:
                 case 10362:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_VEZAX)) == 0;
+                    return (mask & (1 << BOSS_VEZAX)) == 0;
                 case 10350:
                 case 10364:
-                    return (C_of_Ulduar_MASK & (1 << BOSS_YOGGSARON)) == 0;
+                    return (mask & (1 << BOSS_YOGGSARON)) == 0;
             }
             return false;
         }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -300,6 +300,17 @@ enum UlduarGameObjects
     GO_GIFT_OF_THE_OBSERVER_25              = 194822,
 };
 
+enum UlduarPersistentData
+{
+    PERSISTENT_DATA_WATCHERS_MASK           = 0,
+    PERSISTENT_DATA_CONSPEEDATORY,
+    PERSISTENT_DATA_UNBROKEN,
+    PERSISTENT_DATA_ALGALON_TIMER,
+    PERSISTENT_DATA_C_OF_ULDUAR_MASK,
+    PERSISTENT_DATA_MAGE_BARRIER,
+    MAX_PERSISTENT_DATA
+};
+
 enum UlduarMisc
 {
     // Flame Leviathan


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Migrates the Ulduar instance script to use the built-in `DoorData` and `StorePersistentData` systems, removing manual door manipulation and explicit `SaveToDB()` calls. Cross-referenced with TrinityCore's implementation for completeness.

### DoorData (6 → 22 entries)

Expanded the `DoorData` array to cover all boss-associated doors:

| Doors Added | Boss | Type |
|---|---|---|
| `GO_LIGHTNING_WALL1` | Leviathan | PASSAGE |
| `GO_MIMIRON_DOOR_1/2/3` | Mimiron | ROOM |
| `GO_HODIR_FRONTDOOR` | Hodir | ROOM |
| `GO_HODIR_FROZEN_DOOR`, `GO_HODIR_DOOR` | Hodir | PASSAGE |
| `GO_KEEPERS_GATE` ×4 | Hodir/Mimiron/Thorim/Freya | PASSAGE |
| `GO_VEZAX_DOOR` | Vezax | PASSAGE |
| `GO_DOODAD_UL_SIGILDOOR_03` | Algalon | ROOM |
| `GO_DOODAD_UL_UNIVERSEFLOOR_01` | Algalon | ROOM |
| `GO_DOODAD_UL_UNIVERSEFLOOR_02` | Algalon | SPAWN_HOLE |
| `GO_DOODAD_UL_UNIVERSEGLOBE01` | Algalon | SPAWN_HOLE |
| `GO_DOODAD_UL_ULDUAR_TRAPDOOR_03` | Algalon | SPAWN_HOLE |

The Keepers Gate uses 4 PASSAGE entries (one per keeper boss) so DoorData automatically opens it only when all 4 keepers are defeated — matching TrinityCore's pattern and replacing the manual 4-boss check.

### Persistent Data

Converted 6 member variables to `StorePersistentData`/`GetPersistentData` with automatic save-on-change:
- `m_watchersMask` → `PERSISTENT_DATA_WATCHERS_MASK`
- `m_conspeedatoryAttempt` → `PERSISTENT_DATA_CONSPEEDATORY`
- `m_unbrokenAchievement` → `PERSISTENT_DATA_UNBROKEN`
- `m_algalonTimer` → `PERSISTENT_DATA_ALGALON_TIMER`
- `C_of_Ulduar_MASK` → `PERSISTENT_DATA_C_OF_ULDUAR_MASK`
- `m_mageBarrier` → `PERSISTENT_DATA_MAGE_BARRIER`

Removed `ReadSaveDataMore`/`WriteSaveDataMore` overrides (persistent data auto-saves/loads). Added `Load()` override for post-load Algalon timer adjustment.

### Boss Script Cleanup

Removed redundant manual door manipulation from:
- **boss_mimiron.cpp** — 3 door loops (`ResetGameObjects`, `CloseDoorAndButton`, V0L7R0N death)
- **boss_hodir.cpp** — Front door toggle in `Reset`/`JustEngagedWith`/`JustDied`, frozen door + back door opens
- **boss_general_vezax.cpp** — Door open from `JustDied`

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used.

## Issues Addressed:

- Closes

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). Cross-referenced with TrinityCore 3.3.5 branch `instance_ulduar.cpp` for DoorData completeness — the Keepers Gate multi-PASSAGE pattern, Algalon ROOM/SPAWN_HOLE pattern, and Thorim encounter door were verified against TC's implementation.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar and engage each boss that had door changes (Mimiron, Hodir, Vezax, Algalon)
2. Verify doors close on engage and open on wipe/kill
3. Verify Keepers Gate opens after defeating all 4 keepers (Hodir, Mimiron, Thorim, Freya)
4. Verify Algalon encounter objects (sigil door, universe floors, globe, trapdoor) toggle correctly on engage/disengage
5. Verify Hodir passage doors (frozen door, back door) open permanently after kill
6. Verify Vezax door opens permanently after kill
7. Test instance save/load — defeat a boss, leave, re-enter, verify door states are restored correctly
8. Verify Algalon timer persists across instance reloads

## Known Issues and TODO List:

- [ ] Changes the save format — existing in-progress Ulduar lockouts will reset their extra data (watchers mask, algalon timer, etc.) on first load. Weekly reset handles this naturally.
- [ ] BossBoundaryData (present in TrinityCore) not added — separate feature, separate PR.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.